### PR TITLE
Fix host_info detection

### DIFF
--- a/crossenv/__init__.py
+++ b/crossenv/__init__.py
@@ -385,8 +385,8 @@ class CrossEnvBuilder(venv.EnvBuilder):
             sysname = sys.platform[0]
             machine = platform.machine()
         else:
-            sysname = sys.platform[0]
-            machine = sys.platform[-1]
+            sysname = host_info[0]
+            machine = host_info[-1]
 
         config['uname'] = {
             'sysname' : sysname.title(),


### PR DESCRIPTION
1. Fix likely typo. When _PYTHON_HOST_PLATFORM in the Makefile is detected, is
something like 'linux-x86_64', and is split correctly into ['linux', 'x86_64'],
use it for setting sysname and machine. Otherwise, sys.platform (which is a
string, something like 'linux') will get parsed into a sysname of 'l' and
a machine of 'x', almost certainly not the intention.

Fixes #17 