### PR TITLE
Be more careful about things that might already be imported

### DIFF
--- a/crossenv/scripts/site.py.tmpl
+++ b/crossenv/scripts/site.py.tmpl
@@ -81,12 +81,21 @@ class CrossenvFinder(importlib.abc.MetaPathFinder):
     """
 
     PATCHES = {
+        'importlib.machinery': '{{context.lib_path}}/importlib-machinery-patch.py',
+        'sys': '{{context.lib_path}}/sys-patch.py',
+        'os': '{{context.lib_path}}/os-patch.py',
         'sysconfig': '{{context.lib_path}}/sysconfig-patch.py',
         'distutils.sysconfig': '{{context.lib_path}}/distutils-sysconfig-patch.py',
         'platform': '{{context.lib_path}}/platform-patch.py',
         'pkg_resources': '{{context.lib_path}}/pkg_resources-patch.py',
         'pip._vendor.pkg_resources': '{{context.lib_path}}/pkg_resources-patch.py',
     }
+
+    def __init__(self):
+        # At startup, manually patch things that have already been loaded.  We
+        # can't re-load them because they might be used in many places already.
+        # This will be importlib.machinery, sys, and os at the very least.
+        self.manually_patch_loaded()
 
     def find_spec(self, fullname, path, target=None):
         spec = self._find_sysconfigdata(fullname, path, target)
@@ -124,6 +133,18 @@ class CrossenvFinder(importlib.abc.MetaPathFinder):
         spec.loader = CrossenvPatchLoader(spec.loader, patch)
         return spec
 
+    def manually_patch_loaded(self):
+        # do this one first so import machinery works for any subsequent
+        # patches
+        import importlib.machinery
+        _patch_module(importlib.machinery, self.PATCHES['importlib.machinery'])
+
+        for name, module in sys.modules.items():
+            if name == 'importlib.machinery':
+                continue
+            if name in self.PATCHES:
+                _patch_module(module, self.PATCHES[name])
+
 # add just before the real path finder
 try:
     _index = sys.meta_path.index(importlib.machinery.PathFinder)
@@ -131,14 +152,9 @@ except ValueError:
     _index = 0
 sys.meta_path.insert(_index, CrossenvFinder())
 
-# Fixup sys, os, etc. We can't safely re-import them, because they're already
-# being used in many places, so we'll manually apply the patch. Do importlib.machinery
-# first so that our imports work for the others.
-_patch_module(importlib.machinery, '{{context.lib_path}}/importlib-machinery-patch.py')
-_patch_module(sys, '{{context.lib_path}}/sys-patch.py')
-_patch_module(os, '{{context.lib_path}}/os-patch.py')
-
 # Re-import the real site module, so Python can continue booting. Crossenv is
-# ready!
+# ready! We do want to remove sysconfig or any other module that relies on
+# patching after site has messed with sys.
 del sys.modules['site']
+sys.modules.pop('sysconfig', None)
 import site

--- a/crossenv/scripts/sysconfig-patch.py.tmpl
+++ b/crossenv/scripts/sysconfig-patch.py.tmpl
@@ -1,7 +1,12 @@
 # Patch the things that depend on os.environ
 _PROJECT_BASE = {{repr(self.host_project_base)}}
 
-_PYTHON_BUILD = is_python_build(True) # re-eval after patching
+# Things that need to be re-evaluated after patching
+_PYTHON_BUILD = is_python_build(True)
+_PREFIX = os.path.normpath(sys.prefix)
+_BASE_PREFIX = os.path.normpath(sys.base_prefix)
+_EXEC_PREFIX = os.path.normpath(sys.exec_prefix)
+_BASE_EXEC_PREFIX = os.path.normpath(sys.base_exec_prefix)
 
 def get_makefile_filename():
     return {{repr(self.host_makefile)}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from . import testutils
 # Fixtures for everyone. Make sure to include fixture-of-fixture
 # dependencies...
 from .resources import host_python, build_python, architecture, \
-        python_version, get_resource
+        python_version, get_resource, crossenv_setup
 
 def pytest_addoption(parser):
     parser.addoption('--coverage', action='store_true',

--- a/tests/prebuilt/src/CMakeLists.txt
+++ b/tests/prebuilt/src/CMakeLists.txt
@@ -379,6 +379,7 @@ foreach(index RANGE ${num_versions})
         INSTALL_DIR         ${CMAKE_INSTALL_PREFIX}/python/${pyversion}/build
         DOWNLOAD_DIR        python-download
         SOURCE_DIR          python-source-${pyversion}
+        BINARY_DIR          ${CMAKE_INSTALL_PREFIX}/python-obj/${pyversion}/build
         ${download}
         CONFIGURE_COMMAND   <SOURCE_DIR>/configure
                                 --prefix=<INSTALL_DIR>
@@ -408,6 +409,7 @@ foreach(index RANGE ${num_versions})
         INSTALL_DIR         ${CMAKE_INSTALL_PREFIX}/python/${pyversion}/aarch64
         DOWNLOAD_COMMAND    ""
         SOURCE_DIR          python-source-${pyversion}
+        BINARY_DIR          ${CMAKE_INSTALL_PREFIX}/python-obj/${pyversion}/aarch64
         CONFIGURE_COMMAND   ${CMAKE_COMMAND} -E env PATH=${BUILD_PYTHON_PATH}
                             <SOURCE_DIR>/configure
                                 --prefix=<INSTALL_DIR>
@@ -443,6 +445,7 @@ foreach(index RANGE ${num_versions})
         INSTALL_DIR         ${CMAKE_INSTALL_PREFIX}/python/${pyversion}/armhf
         DOWNLOAD_COMMAND    ""
         SOURCE_DIR          python-source-${pyversion}
+        BINARY_DIR          ${CMAKE_INSTALL_PREFIX}/python-obj/${pyversion}/armhf
         CONFIGURE_COMMAND   ${CMAKE_COMMAND} -E env PATH=${BUILD_PYTHON_PATH}
                             <SOURCE_DIR>/configure
                                 --prefix=<INSTALL_DIR>


### PR DESCRIPTION
We need to ensure that sysconfig is patched after importing the real
site module. For good measure we make the manual patch process part of
the finder, which will prevent reloading from causing issues.

Closes #63