### PR TITLE
Handle case where host-python was natively compiled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 - Correctly handle the case where host-python was natively built on another
   architecture.
+- Get uname machine info from `HOST_GNU_TYPE` instead of the platform name. The
+  latter usually uses a generic name that can cause trouble when naming wheels.
 
 ## [1.1.1] - 2020-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Correctly handle the case where host-python was natively built on another
+  architecture.
+
 ## [1.1.1] - 2020-03-28
 
 ### Added


### PR DESCRIPTION
See [PyO3/setuptools_rust #141](https://github.com/PyO3/setuptools-rust/pull/141). Sadly lacking in tests, because we need
to rethink how we test a little bit anyway.