### PR TITLE
Fix distutils.sysconfig patching for Python 3.10

### DIFF
--- a/crossenv/scripts/distutils-sysconfig-patch.py.tmpl
+++ b/crossenv/scripts/distutils-sysconfig-patch.py.tmpl
@@ -1,23 +1,27 @@
 # Patch the things that depend on os.environ or sys
 # This is very similar to the sysconfig patch
 
-project_base = {{repr(self.host_project_base)}}
+# Only patch if get_config_vars was implemented in this module. Python 3.10
+# merged the implementations by importing from sysconfig, so we don't need to
+# patch twice.
+if get_config_vars.__module__ == __name__:
+    project_base = {{repr(self.host_project_base)}}
 
-def get_makefile_filename():
-    return {{repr(self.host_makefile)}}
+    def get_makefile_filename():
+        return {{repr(self.host_makefile)}}
 
-__real_init_posix = _init_posix
-def _init_posix():
-    old = os.environ.get('_PYTHON_SYSCONFIGDATA_NAME')
-    os.environ['_PYTHON_SYSCONFIGDATA_NAME'] = {{repr(sysconfig_name)}}
-    try:
-        return __real_init_posix()
-    finally:
-        if old is None:
-            del os.environ['_PYTHON_SYSCONFIGDATA_NAME']
-        else:
-            os.environ['_PYTHON_SYSCONFIGDATA_NAME'] = old
+    __real_init_posix = _init_posix
+    def _init_posix():
+        old = os.environ.get('_PYTHON_SYSCONFIGDATA_NAME')
+        os.environ['_PYTHON_SYSCONFIGDATA_NAME'] = {{repr(sysconfig_name)}}
+        try:
+            return __real_init_posix()
+        finally:
+            if old is None:
+                del os.environ['_PYTHON_SYSCONFIGDATA_NAME']
+            else:
+                os.environ['_PYTHON_SYSCONFIGDATA_NAME'] = old
 
-assert _config_vars is None, "sysconfig was set up prior to patching?"
+    assert _config_vars is None, "distutils.sysconfig was set up prior to patching?"
 
 #vi: ft=python


### PR DESCRIPTION
Closes #70

In Python 3.10, `distutils.sysconfig` is implemented by importing equivalent functions from `sysconfig`, so we shouldn't attempt to patch it twice.

Note: Need to add automated Python 10 tests. That's not done here.