### PR TITLE
Provide empty lines if there is no Makefile

### DIFF
--- a/crossenv/__init__.py
+++ b/crossenv/__init__.py
@@ -334,6 +334,8 @@ class CrossEnvBuilder(venv.EnvBuilder):
                     if host_platform:
                         self.host_platform = host_platform
                     break
+        else:
+            lines = []
 
         if self.host_platform is None:
             # It was probably natively compiled, but not necessarily for this


### PR DESCRIPTION
This is a follow-up to #82 as the `lines` array is also later used to search for the macosx deployment target.