### PR TITLE
Replace removed sysconfig._is_python_source_dir with equivalent

### DIFF
--- a/crossenv/__init__.py
+++ b/crossenv/__init__.py
@@ -228,6 +228,18 @@ class CrossEnvBuilder(venv.EnvBuilder):
             raise FileNotFoundError("No _sysconfigdata*.py found in host lib")
 
 
+    def _is_python_source_dir(self, d):
+        fn = getattr(sysconfig, '_is_python_source_dir', None)
+        if fn:
+            return fn(d)
+
+        # removed in python 3.11
+        for fn in ("Setup", "Setup.local"):
+            if os.path.isfile(os.path.join(d, "Modules", fn)):
+                return True
+        return False
+
+
     def find_host_python(self, host):
         """
         Find Python paths and other info based on a path.
@@ -245,7 +257,7 @@ class CrossEnvBuilder(venv.EnvBuilder):
         else:
             self.host_project_base = os.path.dirname(host)
 
-        if sysconfig._is_python_source_dir(self.host_project_base):
+        if self._is_python_source_dir(self.host_project_base):
             self.host_makefile = os.path.join(self.host_project_base, 'Makefile')
             pybuilddir = os.path.join(self.host_project_base, 'pybuilddir.txt')
             try:


### PR DESCRIPTION
For #103 , but Python 3.11 still doesn't work. Tested with 3.11 final release. Heres the errors I'm still getting.

```
# python3.11 -m crossenv /build/crosspy/bin/python3.11 /build/venv --sysroot=$(arm-frc2023-linux-gnueabi-gcc -print-sysroot) --env UNIXCONFDIR=/build/venv/cross/etc -vvvv
WARNING: CC is a compound command (['arm-frc2023-linux-gnueabi-gcc', '-pthread'])
WARNING: This can cause issues for modules that don't expect it.
WARNING: Consider setting CC='arm-frc2023-linux-gnueabi-gcc' and CFLAGS='-pthread'
WARNING: CXX is a compound command (['arm-frc2023-linux-gnueabi-c++', '-pthread'])
WARNING: This can cause issues for modules that don't expect it.
WARNING: Consider setting CXX='arm-frc2023-linux-gnueabi-c++' and CXXFLAGS='-pthread'
WARNING: The cross-compiler ('arm-frc2023-linux-gnueabi-gcc -pthread') does not appear to be for the correct architecture (got arm-nilrt-linux-gnueabi, expected armv7l-frc2023-linux-gnueabi). Use --cc to correct, if necessary.
INFO: Creating build-python environment
INFO: Creating cross-python environment
INFO: Installing cross-pip
DEBUG: Installing: ['pip==22.3', 'setuptools==65.5.0']
/build/venv/cross/bin/python3.11: No module named pip
INFO: Finishing up...
```
I looked at it for awhile and... I'm not really sure what's going on. I'm open to looking into this more if you can give me some hints. 
