### PR TITLE
Fix Python 3.11 by removing use of sysconfig._is_python_source_dir

### DIFF
--- a/crossenv/__init__.py
+++ b/crossenv/__init__.py
@@ -16,7 +16,7 @@ import platform
 import pprint
 import re
 
-from .utils import F
+from .utils import F, is_python_source_dir
 from . import utils
 
 __version__ = '1.3.0'
@@ -245,7 +245,7 @@ class CrossEnvBuilder(venv.EnvBuilder):
         else:
             self.host_project_base = os.path.dirname(host)
 
-        if sysconfig._is_python_source_dir(self.host_project_base):
+        if is_python_source_dir(self.host_project_base):
             self.host_makefile = os.path.join(self.host_project_base, 'Makefile')
             pybuilddir = os.path.join(self.host_project_base, 'pybuilddir.txt')
             try:

--- a/crossenv/utils.py
+++ b/crossenv/utils.py
@@ -125,3 +125,10 @@ def install_script(name, dst, context=None, perms=0o755):
 
     with overwrite_file(dst, perms=perms) as fp:
         fp.write(src)
+
+
+def is_python_source_dir(d):
+    for fn in ("Setup", "Setup.local"):
+        if os.path.isfile(os.path.join(d, "Modules", fn)):
+            return True
+    return False


### PR DESCRIPTION
Added to conda-forge in https://github.com/conda-forge/crossenv-feedstock/pull/34 and I've tested locally that it works as expected.

I suspect there might be some more issues with crossenv that result from https://github.com/python/cpython/issues/89745 and/or https://github.com/python/cpython/issues/89183 but I've not yet found anything specific.