### PR TITLE
Write crossenv 'leaked into interpreter' warning message to stderr

### DIFF
--- a/crossenv/scripts/site.py.tmpl
+++ b/crossenv/scripts/site.py.tmpl
@@ -11,12 +11,12 @@ import posix
 
 _sentinel = posix.environ.get(b"PYTHON_CROSSENV")
 if _sentinel != b"{{context.sentinel}}":
-    print("*******************************************************")
-    print("* Crossenv has leaked into another Python interpreter!")
-    print("* You should probably file a bug report.")
-    print("* Version %s" % sys.version)
-    print("* Executable %s" % sys.executable)
-    print("*******************************************************")
+    print("*******************************************************", file=sys.stderr)
+    print("* Crossenv has leaked into another Python interpreter!", file=sys.stderr)
+    print("* You should probably file a bug report.", file=sys.stderr)
+    print("* Version %s" % sys.version, file=sys.stderr)
+    print("* Executable %s" % sys.executable, file=sys.stderr)
+    print("*******************************************************", file=sys.stderr)
 
 import os
 import importlib.machinery


### PR DESCRIPTION
Ran into a leak error on Python 3.14, and it was especially angry because the caller was capturing stdout. Warnings should be written to stderr anyways?